### PR TITLE
Double quote catalog identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.1] - 2023-12-27
+
 ### Features
 
 -   Add homepage and repository to pyproject.toml
@@ -14,6 +16,8 @@ All notable changes to this project will be documented in this file.
 
 -   Adds a basic Trino adapter with most common connection options.
 
-[Unreleased]: https://github.com/TylerHillery/harlequin-trino/compare/0.1.0...HEAD
+[Unreleased]: https://github.com/TylerHillery/harlequin-trino/compare/0.1.1...HEAD
+
+[0.1.1]: https://github.com/TylerHillery/harlequin-trino/compare/0.1.0...0.1.1
 
 [0.1.0]: https://github.com/TylerHillery/harlequin-trino/compare/90c497bd17598b19b510c2a5dbe0c996bd4b6779...0.1.0

--- a/src/harlequin_trino/adapter.py
+++ b/src/harlequin_trino/adapter.py
@@ -194,7 +194,7 @@ class HarlequinTrinoConnection(HarlequinConnection):
             SELECT
                 column_name,
                 data_type 
-            FROM {catalog}.information_schema.columns
+            FROM "{catalog}".information_schema.columns
             WHERE 
                 table_schema = '{schema}'
                 and table_name = '{rel}'

--- a/src/harlequin_trino/adapter.py
+++ b/src/harlequin_trino/adapter.py
@@ -164,7 +164,7 @@ class HarlequinTrinoConnection(HarlequinConnection):
 
     def _get_schemas(self, catalog: str) -> list[tuple[str]]:
         cur = self.conn.cursor()
-        cur.execute(f"SHOW SCHEMAS FROM {catalog}")
+        cur.execute(f"SHOW SCHEMAS FROM \"{catalog}\"")
         results: list[tuple[str]] = cur.fetchall()
         cur.close()
         return [result for result in results if result[0] != "information_schema"]


### PR DESCRIPTION
Double quote catalog identifier to avoid syntax error for catalog names with unsupported characters.