### PR TITLE
fix: repect catalog and schema CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixes
+
+-   Respect catalog and schema CLI options when browsing database catalogs, preventing errors from querying all catalogs ([#17](https://github.com/TylerHillery/harlequin-trino/issues/17))
+
 ## [0.1.5] - 2025-04-14
 
 ### Features

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: check
 check:
 	ruff format .
-	ruff . --fix
+	ruff check . --fix
 	mypy
 	pytest
 

--- a/src/harlequin_trino/adapter.py
+++ b/src/harlequin_trino/adapter.py
@@ -87,6 +87,9 @@ class HarlequinTrinoConnection(HarlequinConnection):
         schema = modified_options.pop("schema", None)
         catalog = modified_options.pop("catalog", None)
 
+        self.catalog_filter = catalog
+        self.schema_filter = schema
+
         if auth == "password":
             user = modified_options.get("user")
             modified_options["auth"] = BasicAuthentication(user, password)
@@ -121,10 +124,18 @@ class HarlequinTrinoConnection(HarlequinConnection):
         return HarlequinTrinoCursor(cur)
 
     def get_catalog(self) -> Catalog:
-        catalogs = self._get_catalogs()
+        if self.catalog_filter:
+            catalogs = [(self.catalog_filter,)]
+        else:
+            catalogs = self._get_catalogs()
+
         db_items: list[CatalogItem] = []
         for (catalog,) in catalogs:
-            schemas = self._get_schemas(catalog)
+            if self.schema_filter:
+                schemas = [(self.schema_filter,)]
+            else:
+                schemas = self._get_schemas(catalog)
+
             schema_items: list[CatalogItem] = []
             for (schema,) in schemas:
                 relations = self._get_relations(catalog, schema)

--- a/trino/etc/catalog/test_catalog.properties
+++ b/trino/etc/catalog/test_catalog.properties
@@ -1,0 +1,4 @@
+connector.name=postgresql
+connection-url=jdbc:postgresql://db:5432/postgres
+connection-user=postgres
+connection-password=postgres


### PR DESCRIPTION
## Summary

• Fix catalog browsing to respect --catalog and --schema CLI options
• Prevent errors from querying misconfigured or problematic catalogs when specific catalog/schema is provided

## Changes

• Modified HarlequinTrinoConnection to store catalog and schema filter options from CLI
• Updated get_catalog() method to only query specified catalog/schema instead of all available ones
• Added test catalog configuration for verifying filtering functionality

Closes #17

## Screenshots

Only shows public schemas when public is passed in 
` harlequin -P None -a trino --host localhost -p 8080 -U trino --schema public`
<img width="409" height="131" alt="image" src="https://github.com/user-attachments/assets/b3ce53c9-b41f-4da4-9e70-dd4a4041545e" />

Only shows my_catalog when my_catalog is passed in
` harlequin -P None -a trino --host localhost -p 8080 -U trino --catalog my_catalog`
<img width="416" height="194" alt="image" src="https://github.com/user-attachments/assets/4cb3ccb5-93f6-479f-a7ba-f4490e04ea25" />

## Other

Just as an FYI much of this code was generate by opencoded here was the session
https://opencode.ai/s/heIgQ5UY