### PR TITLE
feat(auth): add oauth2

### DIFF
--- a/src/harlequin_trino/adapter.py
+++ b/src/harlequin_trino/adapter.py
@@ -16,7 +16,7 @@ from textual_fastdatatable.backend import AutoBackendType
 
 from harlequin_trino.cli_options import TRINO_OPTIONS
 from harlequin_trino.completions import load_completions
-from trino.auth import BasicAuthentication, JWTAuthentication
+from trino.auth import BasicAuthentication, JWTAuthentication, OAuth2Authentication
 from trino.dbapi import connect
 
 
@@ -105,6 +105,10 @@ class HarlequinTrinoConnection(HarlequinConnection):
             modified_options["verify"] = True
             modified_options["schema"] = schema
             modified_options["catalog"] = catalog
+        elif auth == "oauth2":
+            user = modified_options.get("user")
+            modified_options["auth"] = OAuth2Authentication()
+            modified_options["http_scheme"] = "https"
 
         try:
             self.conn = connect(**modified_options)

--- a/src/harlequin_trino/cli_options.py
+++ b/src/harlequin_trino/cli_options.py
@@ -58,7 +58,7 @@ require_auth = SelectOption(
         "if the authentication handshake is not fully completed by the server, the "
         "connection will fail."
     ),
-    choices=["password", "google", "none"],
+    choices=["password", "google", "oauth2", "none"],
 )
 
 sslcert = PathOption(


### PR DESCRIPTION
Add oauth2. Tested on my orgs trino cluster.


Unrelated but I noticed that discovery is poor if a catalog and schema are not provided which seems odd given that is one of the major selling points of trino. When a catalog and schema are provided the UI works as expected...